### PR TITLE
Add local addon to toggle 'disabled' flag in frontmatter

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "slidev-addon-oxrse-training-only-slides",
+  "version": "0.0.1",
+  "description": "Slidev addon for OxRSE training event to toggle 'disabled' flag in the frontmatter"
+}

--- a/addon/setup/preparser.ts
+++ b/addon/setup/preparser.ts
@@ -1,0 +1,8 @@
+import { definePreparserSetup } from '@slidev/types'
+
+export default definePreparserSetup(() => [{
+  transformSlide(content, frontmatter) {
+    if (frontmatter['training-event-only'] && !process.env.TRAINING_EVENT)
+      frontmatter.disabled = true
+  },
+}])


### PR DESCRIPTION
This PR follows the procedures in [pre-parser](https://sli.dev/custom/config-parser) to make an addon to allow toggling the `disabled` flag in slide frontmatter so orientation slides etc will be shown when `TRAINING_EVENT` is defined, otherwise it set `disabled` to `true` so hide the slides. 

To use this functionality, in the slide frontmatter, include `training-event-only: true` to indicate that this slide is meant to be shown only when `TRAINING_EVENT` is set.