### PR TITLE
Minor polishing for functional slides

### DIFF
--- a/courses/functional/main.md
+++ b/courses/functional/main.md
@@ -81,7 +81,7 @@ class: text-xl
 
 <style>
     strong { color: var(--oxrse-bg-colour); }
-    ul li::marker { color: var(--oxrse-bg-colour); }    
+    ul li::marker { color: var(--oxrse-bg-colour); }
     h2 { @apply mt-4 mb-4; }
 </style>
 
@@ -117,7 +117,7 @@ Most useful programs are impure anyway…
 
 <style>
     strong { color: var(--oxrse-bg-colour); }
-    ul li::marker { color: var(--oxrse-bg-colour); }    
+    ul li::marker { color: var(--oxrse-bg-colour); }
     ul { @apply flex flex-col h-100 justify-evenly text-xl }
     .two-cols-header { column-gap: 10px; }
 </style>
@@ -168,7 +168,7 @@ layout: two-cols-header
 
 <style>
     strong { color: var(--oxrse-bg-colour); }
-    ul li::marker { color: var(--oxrse-bg-colour); }    
+    ul li::marker { color: var(--oxrse-bg-colour); }
     ul { @apply flex flex-col h-100 justify-evenly text-2xl }
     .two-cols-header { column-gap: 30px; }
     p { @apply leading-tight }
@@ -211,7 +211,7 @@ print(df2)
 It offers a functional interface but uses non-functional features under the hood and won’t actually copy data unless it needs to.
 
 <style>
-    ul li::marker { color: var(--oxrse-bg-colour); }    
+    ul li::marker { color: var(--oxrse-bg-colour); }
     .two-cols-header { column-gap: 50px; }
     p { @apply leading-normal }
 </style>
@@ -247,8 +247,8 @@ https://en.wikipedia.org/wiki/File:Alonzo_Church.jpg
 ::
 
 <style>
-    strong { color: var(--oxrse-bg-colour); }    
-    ul li::marker { color: var(--oxrse-bg-colour); }    
+    strong { color: var(--oxrse-bg-colour); }
+    ul li::marker { color: var(--oxrse-bg-colour); }
     a { @apply text-sm }
     p { @apply leading-tight }
 </style>
@@ -269,7 +269,7 @@ https://en.wikipedia.org/wiki/File:Alonzo_Church.jpg
 
 <style>
     strong { color: var(--oxrse-bg-colour); }
-    ul li::marker { color: var(--oxrse-bg-colour); }    
+    ul li::marker { color: var(--oxrse-bg-colour); }
     ul { @apply flex flex-col h-100 justify-evenly text-xl }
     p { @apply leading-none }
 </style>
@@ -541,10 +541,10 @@ def say_hello():
 # A classic recursion example
 
 <div class = "flex flex-col h-100 justify-evenly">
-<div class = "text-3xl"> 
+<div class = "text-3xl">
 Possible definitions of the factorial function:
-</div>  
-<div class = "flex justify-between w-full">    
+</div>
+<div class = "flex justify-between w-full">
 <div>
 Imperative:
 
@@ -555,10 +555,10 @@ def factorial(n):
         result = result * i
     return result
 ```
-    
+
 </div>
 <div>
-    
+
 Mathematical:
 
 $$
@@ -577,7 +577,7 @@ def factorial(n):
 ```
 </div>
 </div>
-  
+
 <div class = "text-2xl">
 
 **Caveats**: What happens if you pass a negative number? Or a really big number?

--- a/courses/functional/main.md
+++ b/courses/functional/main.md
@@ -279,7 +279,7 @@ layout: two-cols-header
 class: text-2xl
 ---
 
-# First class functions
+# First-class functions
 
 ::left::
 

--- a/courses/functional/main.md
+++ b/courses/functional/main.md
@@ -439,7 +439,7 @@ reduce((lambda x, y: x + y), [2, 5, 6, 7, 9])
 
 Any time you have a collection of things that needs to be boiled down to a single thing, it can be implemented via a reduction.
 
-You already use reduction functions all the time, e.g.: `sum`, `product`, `mean`, `stdev`, `max`, `min`, `len`, `all`, `any`, etc.
+You already use reduction functions all the time, e.g.: `sum`, `max`, `min`, `len`, `all`, `any`, `prod` (from `math`), `mean` and `stdev` (from `statistics`) etc.
 
 </div>
 

--- a/courses/functional/main.md
+++ b/courses/functional/main.md
@@ -334,7 +334,7 @@ class: text-2xl
 
 **Higher-order functions** are functions that take other functions as arguments.
 
-**Examples**: `map`, `filter` and `reduce` are built-in higher order functions in Python that use lazy evaluation.
+**Examples**: `map`, `filter` (built-in) and `reduce` (from `functools`) are higher-order functions in Python: `map` and `filter` use lazy evaluation while `reduce` returns a single value from the iterable.
 
 </div>
 

--- a/courses/functional/main.md
+++ b/courses/functional/main.md
@@ -203,7 +203,7 @@ import pandas as pd
 
 data = {'A': [1, 2, 3], 'B': [4, 5, 6]}
 df1 = pd.DataFrame(data)
-df2 = df1.rename(columns = {'A': 'a'})
+df2 = df1.rename(columns={'A': 'a'})
 
 print(df2)
 ```
@@ -348,7 +348,7 @@ numbers = [1, 2, 3, 4, 5]
 
 ```python
 # map
-squared= list(map(lambda x: x**2, numbers))
+squared = list(map(lambda x: x**2, numbers))
 print(squared)
 # Output: [1, 4, 9, 16, 25]
 ```
@@ -363,7 +363,7 @@ print(even)
 ```python
 # reduce
 from functools import reduce
-product= reduce((lambda x, y: x * y), numbers)
+product = reduce((lambda x, y: x * y), numbers)
 print(product)
 # Output: 120
 ```
@@ -573,7 +573,7 @@ Functional:
 def factorial(n):
     if n == 0:
         return 1
-    return n * factorial(n- 1)
+    return n * factorial(n - 1)
 ```
 </div>
 </div>

--- a/courses/functional/main.md
+++ b/courses/functional/main.md
@@ -229,7 +229,7 @@ The **λ-calculus**, introduced by Alonzo Church in the 1930s, is the world’s 
 
 It has:
 - Variables: $x$, $y$, etc.
-- Function definitions: $(λ.xM)$, where $M$ is an expression.
+- Function definitions: $(λx.M)$, where $M$ is an expression.
 - Function applications: $(MN)$, where $M$ and $N$ are expressions.
 
 Anything that can be computed at all can be computed with this.

--- a/courses/functional/main.md
+++ b/courses/functional/main.md
@@ -196,7 +196,7 @@ Workarounds involve:
 
 ::right::
 
-Pandas data frames are a good example of a smart data structure:
+Pandas `DataFrame` are a good example of a smart data structure:
 
 ```python
 import pandas as pd

--- a/courses/functional/main.md
+++ b/courses/functional/main.md
@@ -487,7 +487,7 @@ print(squared_dict)
 # Generator
 squared_gen = (x**2 for x in numbers)
 for num in squared_gen:
-print(num)
+    print(num)
 # Output: 1 4 9 16 25
 ```
 


### PR DESCRIPTION
This PR contains some minor fixes for the functional slides:
- fix indentation in one of the Python snippet (would get SyntaxError)
- fix spacing (around = and -) in some of the Python snippets (PEP8)
- clarify what functions are built-in and from the standard libraries
- minor stylistic issue (consistency in hyphenated term, pandas `DataFrame`)

@nicolaspayette one thing I am not sure is the syntax of Lambda calculus, e.g. from our beloved [Wikipedia page for Lambda calculus](https://en.wikipedia.org/wiki/Lambda_calculus), the dot is placed after the variable `x`, while [in the slide ](https://github.com/OxfordRSE/training-course-slides/blob/main/courses/functional/main.md?plain=1#L232), the dot is before `x`. I am not sure if it is a different convention?